### PR TITLE
Set max-width for container

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -70,8 +70,8 @@ footer a {
 
 @media (min-width: 60rem) {
   .container {
-     width: auto;
-     margin: 0 10%;
+     width: 80%;
+     margin: 0 auto;
      border: 1px solid #999;
      border-radius: 5px;
      overflow: hidden;

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -71,6 +71,7 @@ footer a {
 @media (min-width: 60rem) {
   .container {
      width: 80%;
+     max-width: 90em;
      margin: 0 auto;
      border: 1px solid #999;
      border-radius: 5px;


### PR DESCRIPTION
In typograph, it's generally considered that overly long lines of text take longer to read. So let's try to combat that a bit, and cap the max size of the main-container.

We can't really do this based on proper scientific data, because we use proportional fonts, and there's some extra margins etc involved. But we can do something approximate instead.

The exact value is based on taste and trying to make sure text and layout doesn't break too bad in extreme but not too unrealistic sizes. It's not perfect, but probably better than nothing.