### PR TITLE
layout: update links after renaming master to main

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,7 @@
     </div>
 
     <footer>
-      <p><a href="https://github.com/demoscene-no/demoscene-no.github.io/blob/master/{{page.path}}">Foreslå endringer for denne siden</a></p>
+      <p><a href="https://github.com/demoscene-no/demoscene-no.github.io/blob/main/{{page.path}}">Foreslå endringer for denne siden</a></p>
     </footer>
 
   </body>


### PR DESCRIPTION
The new default branch name in Git is "main" and not "master".

To avoid having to fight with re-trained fingers all the time, let's change our default branch as well.

This MR doesn't do the actual rename, that will [happen using the GitHub UI](https://github.com/github/renaming#renaming-existing-branches), but it fixes up the links for the edit-button, which should be done afterwards.