### PR TITLE
files: mark all zip-files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+files/*.zip binary


### PR DESCRIPTION
This is just in case we ever add any zip-files that trip up the CRLF
normalization. No damage happened when importing the current set of
files.