### PR TITLE
add redirects from old php files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "minima", "~> 2.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-paginate"
+  gem "jekyll-redirect-from"
 end
 
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
@@ -84,6 +86,7 @@ DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-feed (~> 0.12)
   jekyll-paginate
+  jekyll-redirect-from
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ url: "http://demoscene.no"
 plugins:
   - jekyll-feed
   - jekyll-paginate
+  - jekyll-redirect-from
 
 paginate: 10
 

--- a/articles.html
+++ b/articles.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: artikler
+redirect_from: artikkel.php/
 ---
 
 {% assign categories = site.articles | group_by: "category" | sort: "name" %}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 path: index.html
+redirect_from:
+  - index.php/
+  - vis.php/
 ---
 <ul id="news">
 {% for post in paginator.posts %}

--- a/links.html
+++ b/links.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: lenker
+redirect_from: link.php/
 ---
 
 {% for category in site.data.links %}


### PR DESCRIPTION
This obviously doesn't cover all cases, because we can't really
redirect from paths with arguments. But it's better than throwing a
404 error, which is what currently happens.