### PR TITLE
update blackvalley.party links

### DIFF
--- a/_posts/2022-01-26-black-valley.md
+++ b/_posts/2022-01-26-black-valley.md
@@ -1,7 +1,7 @@
 ---
 title: "Black Valley 2022"
 author: kusma
-external_link: https://blackvalley.party/
+external_link: https://2022.blackvalley.party/
 ---
 Black Valley er et nytt demoparty i Oslo, Norge i sommer. Organisert av
 folk med erfaring fra tidligere utgaver av [Solskogen], [Kindergarden]

--- a/_posts/2022-06-23-black-valley-billetter.md
+++ b/_posts/2022-06-23-black-valley-billetter.md
@@ -1,7 +1,7 @@
 ---
 title: "Black Valley Billetter"
 author: kusma
-external_link: https://blackvalley.party/news/more-tickets/
+external_link: https://2022.blackvalley.party/news/more-tickets/
 ---
 Den 16 Juli ble Black Valley 2022 billettene lagt ut for salg, men alle
 billettene ble revet vekk i løpet av et snaut døgn.


### PR DESCRIPTION
These links were for the 2022 version of Black Valley, but we've now changed to use yearly URLs, and there's no reasonable way to forward old URLs like these to the right year. Let's update the links instead.